### PR TITLE
improve activity resource

### DIFF
--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -32,7 +32,7 @@ class ActivityResource extends Resource
                 Forms\Components\TextInput::make('causer_id'),
                 Forms\Components\TextInput::make('subject_type'),
                 Forms\Components\TextInput::make('subject_id'),
-                Forms\Components\TextInput::make('description'),
+                Forms\Components\TextInput::make('description')->columnSpan(2),
                 Forms\Components\KeyValue::make('properties.attributes'),
                 Forms\Components\KeyValue::make('properties.old'),
             ]);


### PR DESCRIPTION
small improvement in the activity resource,
make the description input span into two columns, 
to make it easier to see the `properties.attributes` and `properties.old` side by side

![Screen Shot 2022-03-27 at 11 52 38 PM](https://user-images.githubusercontent.com/1952412/160300563-dc39cac8-9f4c-4d93-82c7-5241d6f55485.png)
