### PR TITLE
[fix] ResourceFinder returns null if no resource

### DIFF
--- a/src/ResourceFinder.php
+++ b/src/ResourceFinder.php
@@ -17,5 +17,7 @@ final class ResourceFinder
                 return $resource;
             }
         }
+
+        return null;
     }
 }


### PR DESCRIPTION
If a model has no resource, ResourceFinder returns "AlexJustesen\FilamentSpatieLaravelActivitylog\ResourceFinder::find(): Return value must be of type ?string, none returned".

Added return null after the loop.