### PR TITLE
Allow to show the subject column on relationship managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ You can customise the navigation group for the `ActivityResource` by publishing 
 
 If you have a model that uses the `Spatie\Activitylog\Traits\LogsActivity` trait, you can add the `AlexJustesen\FilamentSpatieLaravelActivitylog\RelationManagers\ActivitiesRelationManager` relationship manager to your Filament resource to display all of the activity logs that are performed on your model.
 
+### Show the `subject` column on custom relation managers
+
+When using the relationship manager the `subject` column isn't shown because the subject is the parent record. There are some cases (like when aggregating activities from child records) where the subject might be another record, and you want to show this column. In those cases you can add the next code to your relation manager:
+
+```php
+public function hideSubjectColumn(): bool
+{
+    return false;
+}
+```
+
 ## Testing
 
 ```bash

--- a/src/Resources/ActivityResource.php
+++ b/src/Resources/ActivityResource.php
@@ -31,7 +31,7 @@ class ActivityResource extends Resource
     {
         return __('filament-spatie-activitylog::activity.plural_label');
     }
-    
+
     public static function form(Form $form): Form
     {
         return $form
@@ -89,7 +89,11 @@ class ActivityResource extends Resource
                     ->searchable(),
                 Tables\Columns\TextColumn::make('subject.name')
                     ->label(__('filament-spatie-activitylog::activity.subject'))
-                    ->hidden(fn (Component $livewire) => $livewire instanceof ActivitiesRelationManager)
+                    ->hidden(function (Component $livewire) {
+                        return method_exists($livewire, 'hideSubjectColumn')
+                            ? call_user_func([$livewire, 'hideSubjectColumn'])
+                            : $livewire instanceof ActivitiesRelationManager;
+                    })
                     ->getStateUsing(function (Activity $record) {
                         if (! $record->subject || ! $record->subject instanceof IsActivitySubject) {
                             return new HtmlString('&mdash;');


### PR DESCRIPTION
Hello,

We have a use case where we aggregate activities from child records on our relationship manager (in this case, we manage orders and want to show on the order page the activity for every line of the order).

This PR allows this without breaking current code.